### PR TITLE
[close #1] Add leaky build path detection

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,21 +5,30 @@ require 'fileutils'
 
 BUILD_DIR = Pathname.new(ARGV[0])
 
+# Build time checking of PATH
 check_script = Pathname.new(__FILE__).join("../../lib/check_script.rb")
 out = `ruby #{check_script}`
 raise "Check script failed:\n#{out}" unless $?.success?
 puts out
 
+# Setting up runtime checking of PATH
 vendor_file = BUILD_DIR.join("bin", "check_paths")
 vendor_file.dirname.mkpath
-
 FileUtils.mv(check_script, vendor_file)
 
+# Record the build dir so that the release phase can check for leaky build dir in the PATH later
+profile_d_dir = BUILD_DIR.join(".profile.d")
+profile_d_dir.mkpath
+profile_d_dir.join("force_absolute_paths_buildpack.sh").write("export FORCE_ABSOLUTE_PATHS_BUILDPACK_BUILD_DIR=#{BUILD_DIR}")
+
+# We execute the check script again in relase phase which is executed in a runtime environment
+# this is accomplished by injecting code into the Procfile
 puts "-----> Updating release script in procfile"
 procfile = BUILD_DIR.join("Procfile")
 
 procfile_written = false
 
+# If a Procfile exists, and the `release:` phase is already defined, append our task to it.
 if procfile.file?
   contents = String.new("")
   procfile.each_line do |line|

--- a/lib/check_script.rb
+++ b/lib/check_script.rb
@@ -3,9 +3,24 @@ STDOUT.sync = true
 
 puts "-----> Checking for absolute values in PATHs"
 
+if ENV["FORCE_ABSOLUTE_PATHS_BUILDPACK_BUILD_DIR"]
+  buildpack_build_dir = ENV["FORCE_ABSOLUTE_PATHS_BUILDPACK_BUILD_DIR"]
+
+  # If the build dir and runtime dir are the same, we don't need to run the check
+  buildpack_build_dir = nil if buildpack_build_dir == File.expand_path(".")
+end
+
 ENV.select {|k,v| k.end_with?("PATH") }.each do |env_key, env_value|
-  if (relative_path = env_value.split(":").detect {|path| !path.start_with?("/")})
+  path_parts = env_value.split(":")
+  # Check relative paths
+  if (relative_path = path_parts.detect {|path| !path.start_with?("/")})
     msg = %Q{All paths must be absolute, ENV["#{env_key}"] contains #{env_value.inspect} with relative_path #{relative_path.inspect}}
+    raise msg
+  end
+
+  # Check for build tmp path leaking into runtime
+  if buildpack_build_dir && (leaky_path = path_parts.detect {|path| path.start_with?(buildpack_build_dir) })
+    msg = %Q{A build path leaked into runtime, ENV["#{env_key}"] contains #{env_value.inspect} with leaky path #{leaky_path.inspect}}
     raise msg
   end
 end

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe "This buildpack" do
 
 
         # Test export
-        echo "PATH=/good/absolute/path:$PATH" >> export
+        echo "export PATH=/good/absolute/path:$PATH" >> export
 
         # Test .profile.d
         BUILD_DIR=$1
         mkdir -p $BUILD_DIR/.profile.d
 
-        echo "PATH=/good/absolute/path:$PATH" >> $BUILD_DIR/.profile.d/my.sh
+        echo "export PATH=/good/absolute/path:$PATH" >> $BUILD_DIR/.profile.d/my.sh
       EOM
     )
 
@@ -36,7 +36,7 @@ RSpec.describe "This buildpack" do
         compile_script: <<~EOM
           #!/usr/bin/env bash
 
-          echo "PATH=bad_export_path_because_im_relative:$PATH" >> export
+          echo "export PATH=bad_export_path_because_im_relative:$PATH" >> export
         EOM
       )
 
@@ -61,7 +61,7 @@ RSpec.describe "This buildpack" do
           BUILD_DIR=$1
           mkdir -p $BUILD_DIR/.profile.d
 
-          echo "PATH=bad_export_path_because_im_relative:$PATH" >> $BUILD_DIR/.profile.d/my.sh
+          echo "export PATH=bad_export_path_because_im_relative:$PATH" >> $BUILD_DIR/.profile.d/my.sh
         EOM
       )
 
@@ -86,7 +86,7 @@ RSpec.describe "This buildpack" do
           BUILD_DIR=$1
           mkdir -p $BUILD_DIR/.profile.d
 
-          echo "PATH=$BUILD_DIR/foo:$PATH" >> $BUILD_DIR/.profile.d/my.sh
+          echo "export PATH=$BUILD_DIR/foo:$PATH" >> $BUILD_DIR/.profile.d/my.sh
         EOM
       )
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "bundler/setup"
 require 'rspec/retry'
 
 ENV["HATCHET_BUILDPACK_BASE"] = "https://github.com/sharpstone/force_absolute_paths_buildpack.git"
+ENV["HATCHET_BUILDPACK_BRANCH"] = ENV["CIRCLE_BRANCH"] if ENV["CIRCLE_BRANCH"]
 
 require 'hatchet'
 require 'pathname'


### PR DESCRIPTION
The build dir and runtime dir are not the same on Heroku so a path like `/tmp/build_asdflasldkfjalsdkj` might be used at build time but at runtime it would be `/app`. It's easy to accidentally put a build path in the PATH at built time and not realize it. This feature detects and errors on this possible failure mode.