### PR TITLE
Check all directories exist

### DIFF
--- a/lib/check_script.rb
+++ b/lib/check_script.rb
@@ -23,6 +23,11 @@ ENV.select {|k,v| k.end_with?("PATH") }.each do |env_key, env_value|
     msg = %Q{A build path leaked into runtime, ENV["#{env_key}"] contains #{env_value.inspect} with leaky path #{leaky_path.inspect}}
     raise msg
   end
+
+  if (not_a_directory = path_parts.detect {|path| !File.directory?(path) })
+    msg = %Q{All paths should be directories, ENV["#{env_key}"] contains #{env_value.inspect} which is not a directory #{not_a_directory.inspect}}
+    raise msg
+  end
 end
 
 puts "       Everything looks good to me"


### PR DESCRIPTION
A possible failure mode is accidentally adding a path that does not exist to the PATH. Another failure mode is adding the file such as `bin/yarn` instead of the directory `bin`. This check guarantees that the directory exists and that it is in fact a directory.