### PR TITLE
Allow ignoring specific paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,19 @@ To https://git.heroku.com/cryptic-gorge-80699.git
 
 - Check all paths are absolute
 - Check the build directory doesn't leak into a path at runtime (if build and runtime dirs are different)
+
+## Ignoring a path
+
+This buildpack is greedy in checking all env vars that end in `_PATH`. If there's a env var that ends in `_PATH` that should be relative, you can ignore it by setting the `FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS` config value on the app. For example:
+
+
+```
+heroku config:set FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS=BUNDLE_PATH
+```
+
+This will tell this buildpack to ignore the `BUNDLE_PATH` env var. You can specify multiple values using a comma:
+
+
+```
+heroku config:set FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS=BUNDLE_PATH,IGNORE_THIS_PATH_TOO
+```

--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,16 @@ require 'pathname'
 require 'fileutils'
 
 BUILD_DIR = Pathname.new(ARGV[0])
+ENV_DIR = Pathname.new(ARGV[2])
+
+# Import env
+if ENV_DIR.exist? && ENV_DIR.directory?
+  ENV_DIR.each_child do |file|
+    key   = file.basename.to_s
+    value = file.read.strip
+    ENV[key] = value if key.upcase.start_with?("FORCE_ABSOLUTE_PATHS")
+  end
+end
 
 # Build time checking of PATH
 check_script = Pathname.new(__FILE__).join("../../lib/check_script.rb")

--- a/lib/check_script.rb
+++ b/lib/check_script.rb
@@ -10,7 +10,14 @@ if ENV["FORCE_ABSOLUTE_PATHS_BUILDPACK_BUILD_DIR"]
   buildpack_build_dir = nil if buildpack_build_dir == File.expand_path(".")
 end
 
+ignore_paths = ENV.fetch("FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS", "").split(",").each_with_object({}) {|path, hash| hash[path.upcase] = true }
+
 ENV.select {|k,v| k.end_with?("PATH") }.each do |env_key, env_value|
+  if ignore_paths.key?(env_key)
+    puts "Ignoring key #{env_key} due to FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS=#{ENV["FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS"]}"
+    next
+  end
+
   path_parts = env_value.split(":")
   # Check relative paths
   if (relative_path = path_parts.detect {|path| !path.start_with?("/")})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,13 +31,19 @@ def spec_dir
   Pathname.new(__dir__)
 end
 
-
 def generate_fixture_app(compile_script:, name: )
   app_dir = spec_dir.join("fixtures/repos/generated/#{name}")
   bin_dir = app_dir.join("bin")
   bin_dir.mkpath
 
   bin_compile = bin_dir.join("compile")
+
+  if bin_compile.file?  && bin_compile.read != compile_script # File already exists, make sure we're not accidentally over-writing
+    puts "WARNING: You are writing over #{bin_compile} with different contents. Ensure each test is using a unique name:"
+    puts
+    puts "Existing contents: #{bin_compile.read.inspect}"
+    puts "New contents:      #{compile_script.inspect}"
+  end
   bin_compile.write(compile_script)
 
   bin_detect = bin_dir.join("detect")


### PR DESCRIPTION
Just because an env var ends in `_PATH` doesn't mean that it MUST be absolute. For example, the `BUNDLE_PATH` is set to `vendor/bundle` on Heroku and attempting to provide it with an absolute path can cause issues. 

This PR allows the app to ignore a specific env var. Using the `FORCE_ABSOLUTE_PATHS_BUILDPACK_IGNORE_PATHS` env var.